### PR TITLE
fix(lib): Update selfCaller to honor x-forwarded-proto when forwarded via CloudFlare Argo Tunnels

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,14 @@ var selfCaller = function (path, req, res, cb, url) {
   var url = req.get('host').split(':');
   var port = url[1];
   url = url[0];
-  var prot = req.protocol === 'https' ? https : http;
+  var prot;
+  if(req.headers['x-forwarded-proto'] && req.headers['cdn-loop'] === 'cloudflare') {
+    let forwardedProto = req.headers['x-forwarded-proto']
+    prot = forwardedProto === 'https' ? https : http;
+    port = forwardedProto === 'https' ? 443 : 80;
+  } else {
+    prot = req.protocol === 'https' ? https : http;
+  }
   var opts = {
     hostname: url,
     method: 'GET',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
When using CloudFlare Argo Tunnels to expose the local environment(Instead of ngrok for example), the selfCaller function fails if the CloudFlare setting to redirect all HTTP -> HTTPS traffic is enabled. From what I've seen, this is due to the protocol detection using the protocol that was used locally, rather than at the edge.

For example:

Submit Middleware Test on FCC site(Requires HTTPS):
1. FCC --> CF URL(https://fcc-backend.test-site.invalid)
2. CF -- Tunnel --> to local dev env. Local env sees the protocol as HTTP
3. Local Server --> Request to http://fcc-backend.test-site.invalid
    - selfCaller() sends a request to the <proto><host> which in this example evaluates to http://fcc-backend.test-site.invalid
4. CloudFlare responds with a 301 Redirect to https://fcc-backend.test-site.invalid. Unfortunately, the http package does not support following redirects as far as I can tell.

This change configures the selfCaller() function to force the port and protocol to be https when the x-forwarded-for and cdn-loop headers are present. As this hasn't caused issue for others from what I can see, I limited the scope to just be CloudFlare specific.